### PR TITLE
Milestones for v0.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.9'
+          - '1.10'
         os:
           - ubuntu-latest
         arch:
@@ -44,34 +44,34 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write # needed to allow julia-actions/cache to proactively delete old caches that it has created
-      contents: write
-      statuses: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1.10'
-      - uses: julia-actions/cache@v2
-      - name: Configure doc environment
-        shell: julia --project=docs --color=yes {0}
-        run: |
-          using Pkg
-          Pkg.develop(PackageSpec(path=pwd()))
-          Pkg.instantiate()
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-docdeploy@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-      - name: Run doctests
-        shell: julia --project=docs --color=yes {0}
-        run: |
-          using Documenter: DocMeta, doctest
-          using RegionGrids
-          DocMeta.setdocmeta!(RegionGrids, :DocTestSetup, :(using RegionGrids); recursive=true)
-          doctest(RegionGrids)
+  # docs:
+  #   name: Documentation
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write # needed to allow julia-actions/cache to proactively delete old caches that it has created
+  #     contents: write
+  #     statuses: write
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: julia-actions/setup-julia@v2
+  #       with:
+  #         version: '1.10'
+  #     - uses: julia-actions/cache@v2
+  #     - name: Configure doc environment
+  #       shell: julia --project=docs --color=yes {0}
+  #       run: |
+  #         using Pkg
+  #         Pkg.develop(PackageSpec(path=pwd()))
+  #         Pkg.instantiate()
+  #     - uses: julia-actions/julia-buildpkg@v1
+  #     - uses: julia-actions/julia-docdeploy@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+  #     - name: Run doctests
+  #       shell: julia --project=docs --color=yes {0}
+  #       run: |
+  #         using Documenter: DocMeta, doctest
+  #         using RegionGrids
+  #         DocMeta.setdocmeta!(RegionGrids, :DocTestSetup, :(using RegionGrids); recursive=true)
+  #         doctest(RegionGrids)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegionGrids"
 uuid = "ecebd26c-3930-4a82-94f6-9df2a191b288"
 authors = ["Nathanael Wong <natgeo.wong@outlook.com>"]
-version = "0.0.3"
+version = "0.1.0"
 desc = "Extracting and Subsetting Gridded Data for a given Geographical Region"
 
 [deps]
@@ -11,7 +11,7 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
 Dates = "1"
-GeoRegions = "7"
+GeoRegions = "8"
 julia = "^1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 [compat]
 Dates = "1"
 Distances = "0.10"
-GeoRegions = "8"
+GeoRegions = "^8.0.1"
 GeometryOps = "0.1"
 Logging = "1"
 julia = "^1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,22 @@
 name = "RegionGrids"
 uuid = "ecebd26c-3930-4a82-94f6-9df2a191b288"
+desc = "Extracting and Subsetting Gridded Data for a given Geographical Region"
 authors = ["Nathanael Wong <natgeo.wong@outlook.com>"]
 version = "0.1.0"
-desc = "Extracting and Subsetting Gridded Data for a given Geographical Region"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 GeoRegions = "b001f823-fa75-4bff-bf55-6610c8f3688a"
+GeometryOps = "3251bfac-6a57-4b6d-aa61-ac1fef2975ab"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
 Dates = "1"
+Distances = "0.10"
 GeoRegions = "8"
+GeometryOps = "0.1"
+Logging = "1"
 julia = "^1.10"
 
 [extras]

--- a/src/RegionGrids.jl
+++ b/src/RegionGrids.jl
@@ -9,10 +9,7 @@ import Base: show
 
 ## Exporting the following functions:
 export
-        RegionGrid,
-        RectilinearGrid,  RLinearMask, RLinearTilt,
-        GeneralizedGrid,  GeneralMask, GeneralTilt, 
-        UnstructuredGrid, VectorMask,  VectorTilt,
+        RegionGrid, RectilinearGrid, GeneralizedGrid, UnstructuredGrid,
 
         extract, extract!
 
@@ -35,40 +32,16 @@ All `RectilinearGrid` types contain the following fields:
 * `mask` - An array of NaNs and 1s, defining a non-rectilinear shape within a rectilinear grid where data is valid (only available in PolyGrid types)
 * `weights` - An array of `Float`s, defining the latitude-weights of each valid point in the grid.
 """
-abstract type RectilinearGrid <: RegionGrid end
-
-"""
-    RLinearMask <: RectilinearGrid
-
-Information on a `RLinearMask` type that is extracted based on a `RectRegion` or `PolyRegion` GeoRegion type.
-"""
-struct RLinearMask{FT<:Real} <: RectilinearGrid
-     lon :: Vector{FT}
-     lat :: Vector{FT}
-    ilon :: Vector{Int}
-    ilat :: Vector{Int}
-    mask :: Array{FT,2}
-    weights :: Array{FT,2}
-end
-
-"""
-    RLinearTilt <: RectilinearGrid
-
-Information on a `RectilinearGrid` type that is extracted based on a `TiltRegion` type.
-
-In addition to all the fields common to the `RectilinearGrid` abstract type, `TiltGrid`s type will also contain the following fields:
-* `rotX` - An array of `Float`s, defining indices of the parent longitude vector describing the region
-* `rotY` - An array of `Float`s, defining indices of the parent latitude vector describing the region
-"""
-struct RLinearTilt{FT<:Real} <: RectilinearGrid
-     lon :: Vector{FT}
-     lat :: Vector{FT}
-    ilon :: Vector{Int}
-    ilat :: Vector{Int}
-    mask :: Array{FT,2}
-    weights :: Array{FT,2}
-    rotX :: Array{FT,2}
-    rotY :: Array{FT,2}
+struct RectilinearGrid{FT<:Real} <: RegionGrid
+         lon :: Vector{FT}
+         lat :: Vector{FT}
+        ilon :: Vector{Int}
+        ilat :: Vector{Int}
+        mask :: Array{FT,2}
+     weights :: Array{FT,2}
+    rotation :: FT
+           X :: FT
+           Y :: FT
 end
 
 """
@@ -82,40 +55,16 @@ All `GeneralizedGrid` type will contain the following fields:
 * `mask` - An array of NaNs and 1s, defining the region within the original field in which data points are valid
 * `weights` - An array of `Float`s, defining the latitude-weights of each valid point in the grid.
 """
-abstract type GeneralizedGrid <: RegionGrid end
-
-"""
-    GeneralMask <: GeneralizedGrid
-
-Information on a `GeneralizedGrid` type that is extracted based on arrays of longitude/latitude points.
-"""
-struct GeneralMask{FT<:Real} <: GeneralizedGrid
-     lon :: Array{FT,2}
-     lat :: Array{FT,2}
-    ilon :: Array{Int}
-    ilat :: Array{Int}
-    mask :: Array{FT,2}
-    weights :: Array{FT,2}
-end
-
-"""
-    GeneralTilt <: GeneralizedGrid
-
-Information on a `GeneralizedGrid` type that is extracted based on arrays of longitude/latitude points.
-
-In addition to all the fields common to the `GeneralizedGrid` abstract type, `RegionTilt`s type will also contain the following fields:
-* `rotX` - An array of `Float`s, defining indices of the parent longitude vector describing the region
-* `rotY` - An array of `Float`s, defining indices of the parent latitude vector describing the region
-"""
-struct GeneralTilt{FT<:Real} <: GeneralizedGrid
-     lon :: Array{FT,2}
-     lat :: Array{FT,2}
-    ilon :: Array{Int}
-    ilat :: Array{Int}
-    mask :: Array{FT,2}
-    weights :: Array{FT,2}
-    rotX :: Array{FT,2}
-    rotY :: Array{FT,2}
+struct GeneralizedGrid{FT<:Real} <: RegionGrid
+         lon :: Array{FT,2}
+         lat :: Array{FT,2}
+        ilon :: Array{Int}
+        ilat :: Array{Int}
+        mask :: Array{FT,2}
+     weights :: Array{FT,2}
+    rotation :: FT
+           X :: FT
+           Y :: FT
 end
 
 """
@@ -129,36 +78,14 @@ All `UnstructuredGrid` type will contain the following fields:
 * `mask` - A vector of NaNs and 1s, defining the region within the original field in which data points are valid
 * `weights` - A vector of `Float`s, defining the latitude-weights of each valid point in the grid.
 """
-abstract type UnstructuredGrid <: RegionGrid end
-
-"""
-    VectorMask <: UnstructuredGrid
-
-Information on a `UnstructuredGrid` type that is extracted based on vectors of longitude and latitude points.
-"""
-struct VectorMask{FT<:Real} <: UnstructuredGrid
-        lon :: Vector{FT}
-        lat :: Vector{FT}
-     ipoint :: Array{Int}
-    weights :: Vector{FT}
-end
-
-"""
-    VectorTilt <: UnstructuredGrid
-
-Information on a `UnstructuredGrid` type that is extracted based on vectors of longitude and latitude points.
-
-A `VectorTilt` type will also contain the following fields:
-* `rotX` - A vector of `Float`s, defining indices of the parent longitude vector describing the region
-* `rotY` - A vector of `Float`s, defining indices of the parent latitude vector describing the region
-"""
-struct VectorTilt{FT<:Real} <: UnstructuredGrid
-        lon :: Vector{FT}
-        lat :: Vector{FT}
-     ipoint :: Array{Int}
-    weights :: Vector{FT}
-       rotX :: Vector{FT}
-       rotY :: Vector{FT}
+struct UnstructuredGrid{FT<:Real} <: RegionGrid
+         lon :: Vector{FT}
+         lat :: Vector{FT}
+      ipoint :: Array{Int}
+     weights :: Vector{FT}
+    rotation :: FT
+           X :: FT
+           Y :: FT
 end
 
 modulelog() = "$(now()) - RegionGrids.jl"

--- a/src/RegionGrids.jl
+++ b/src/RegionGrids.jl
@@ -2,6 +2,8 @@ module RegionGrids
 
 ## Modules Used
 using Dates
+using Distances
+using GeometryOps
 using GeoRegions
 using Logging
 
@@ -33,15 +35,15 @@ All `RectilinearGrid` types contain the following fields:
 * `weights` - An array of `Float`s, defining the latitude-weights of each valid point in the grid.
 """
 struct RectilinearGrid{FT<:Real} <: RegionGrid
-         lon :: Vector{FT}
-         lat :: Vector{FT}
-        ilon :: Vector{Int}
-        ilat :: Vector{Int}
-        mask :: Array{FT,2}
-     weights :: Array{FT,2}
-    rotation :: FT
-           X :: FT
-           Y :: FT
+        lon :: Vector{FT}
+        lat :: Vector{FT}
+       ilon :: Vector{Int}
+       ilat :: Vector{Int}
+       mask :: Array{FT,2}
+    weights :: Array{FT,2}
+          X :: Array{FT,2}
+          Y :: Array{FT,2}
+          θ :: FT
 end
 
 """
@@ -56,15 +58,15 @@ All `GeneralizedGrid` type will contain the following fields:
 * `weights` - An array of `Float`s, defining the latitude-weights of each valid point in the grid.
 """
 struct GeneralizedGrid{FT<:Real} <: RegionGrid
-         lon :: Array{FT,2}
-         lat :: Array{FT,2}
-        ilon :: Array{Int}
-        ilat :: Array{Int}
-        mask :: Array{FT,2}
-     weights :: Array{FT,2}
-    rotation :: FT
-           X :: FT
-           Y :: FT
+        lon :: Array{FT,2}
+        lat :: Array{FT,2}
+       ilon :: Array{Int}
+       ilat :: Array{Int}
+       mask :: Array{FT,2}
+    weights :: Array{FT,2}
+          X :: Array{FT,2}
+          Y :: Array{FT,2}
+          θ :: FT
 end
 
 """
@@ -79,13 +81,13 @@ All `UnstructuredGrid` type will contain the following fields:
 * `weights` - A vector of `Float`s, defining the latitude-weights of each valid point in the grid.
 """
 struct UnstructuredGrid{FT<:Real} <: RegionGrid
-         lon :: Vector{FT}
-         lat :: Vector{FT}
-      ipoint :: Array{Int}
-     weights :: Vector{FT}
-    rotation :: FT
-           X :: FT
-           Y :: FT
+        lon :: Vector{FT}
+        lat :: Vector{FT}
+     ipoint :: Array{Int}
+    weights :: Vector{FT}
+          X :: FT
+          Y :: FT
+          θ :: FT
 end
 
 modulelog() = "$(now()) - RegionGrids.jl"

--- a/src/extract/generalized.jl
+++ b/src/extract/generalized.jl
@@ -11,8 +11,8 @@ Extracts data from odata, an Array that contains data of a Parent `GeoRegion`, i
 
 Arguments
 =========
-- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from
-- `ggrd` : A `RegionGrid` containing detailed information on what to extract
+- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from.
+- `ggrd` : A `RegionGrid` containing detailed information on what to extract.
 """
 function extract(
     odata :: AbstractArray{<:Real},
@@ -44,8 +44,8 @@ end
 
 """
     extract!(
-        odata :: AbstractArray{<:Real},
         ndata :: AbstractArray{<:Real},
+        odata :: AbstractArray{<:Real},
         ggrd  :: GeneralizedGrid
     ) -> nothing
 
@@ -58,9 +58,9 @@ This allows for iterable in-place modification to save memory space and reduce a
 
 Arguments
 =========
-- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from
-- `ndata` : An array of dimension N meant as a placeholder for the extracted data to minimize allocations
-- `ggrd` : A `RegionGrid` containing detailed information on what to extract
+- `ndata` : An array of dimension N meant as a placeholder for the extracted data to minimize allocations.
+- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from.
+- `ggrd` : A `RegionGrid` containing detailed information on what to extract.
 """
 function extract!(
     ndata :: AbstractArray{<:Real},

--- a/src/extract/rectilinear.jl
+++ b/src/extract/rectilinear.jl
@@ -11,8 +11,8 @@ Extracts data from odata, an Array that contains data of a Parent `GeoRegion`, i
 
 Arguments
 =========
-- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from
-- `ggrd` : A `RegionGrid` containing detailed information on what to extract
+- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from.
+- `ggrd` : A `RegionGrid` containing detailed information on what to extract.
 """
 function extract(
     odata :: AbstractArray{<:Real},
@@ -43,8 +43,8 @@ end
 
 """
     extract!(
-        odata :: AbstractArray{<:Real},
         ndata :: AbstractArray{<:Real},
+        odata :: AbstractArray{<:Real},
         ggrd  :: RectilinearGrid
     ) -> nothing
 
@@ -57,9 +57,9 @@ This allows for iterable in-place modification to save memory space and reduce a
 
 Arguments
 =========
-- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from
-- `ndata` : An array of dimension N meant as a placeholder for the extracted data to minimize allocations
-- `ggrd` : A `RegionGrid` containing detailed information on what to extract
+- `ndata` : An array of dimension N meant as a placeholder for the extracted data to minimize allocations.
+- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from.
+- `ggrd` : A `RegionGrid` containing detailed information on what to extract.
 """
 function extract!(
     ndata :: AbstractArray{<:Real},

--- a/src/extract/unstructured.jl
+++ b/src/extract/unstructured.jl
@@ -1,6 +1,6 @@
 """
     extract(
-        odata :: AbstractArray{<:Real},
+        odata :: AbstractVector{<:Real},
         ggrd  :: UnstructuredGrid
     ) -> Array{<:Real}
 
@@ -11,8 +11,8 @@ Extracts data from odata, an Array that contains data of a Parent `GeoRegion`, i
 
 Arguments
 =========
-- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from
-- `ggrd` : A `RegionGrid` containing detailed information on what to extract
+- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from.
+- `ggrd` : A. `UnstructuredGrid` containing detailed information on what to extract.
 """
 function extract(
     odata :: AbstractArray{<:Real},
@@ -20,9 +20,9 @@ function extract(
 )
 
     ipnts = ggrd.ipoint; npnt = length(ipnts)
-    dims = size(odata); not2D = length(dims) > 1
+    dims = size(odata); not1D = length(dims) > 1
 
-    if not2D
+    if not1D
         ndata = zeros(npnt,dims[2:end]...)
         edims = map(x -> 1 : x, dims[2:end])
         for ipnt in 1 : npnt
@@ -41,8 +41,8 @@ end
 
 """
     extract!(
-        odata :: AbstractArray{<:Real},
-        ndata :: AbstractArray{<:Real},
+        ndata :: AbstractVector{<:Real},
+        odata :: AbstractVector{<:Real},
         ggrd  :: UnstructuredGrid
     ) -> nothing
 
@@ -55,9 +55,9 @@ This allows for iterable in-place modification to save memory space and reduce a
 
 Arguments
 =========
-- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from
-- `ndata` : An array of dimension N meant as a placeholder for the extracted data to minimize allocations
-- `ggrd` : A `RegionGrid` containing detailed information on what to extract
+- `ndata` : An array of dimension N meant as a placeholder for the extracted data to minimize allocations.
+- `odata` : An array of dimension N containing gridded data in the region we are interesting in extracting from.
+- `ggrd` : A `UnstructuredGrid` containing detailed information on what to extract.
 """
 function extract!(
     ndata :: AbstractArray{<:Real},
@@ -66,9 +66,9 @@ function extract!(
 )
 
     ipnts = ggrd.ipoint; npnt = length(ipnts)
-    dims = size(odata); not2D = length(dims) > 1
+    dims = size(odata); not1D = length(dims) > 1
 
-    if not2D
+    if not1D
         edims = map(x -> 1 : x, dims[2:end])
         for ipnt in 1 : npnt
             ndata[ipnt,edims...] = odata[ipnts[ipnt],edims...]

--- a/src/grid/generalized.jl
+++ b/src/grid/generalized.jl
@@ -61,15 +61,13 @@ function RegionGrid(
         lon[iilon,iilat] < geo.W ? lon[iilon,iilat] += 360 : nothing
         lat[iilon,iilat] = pnts[iiWE,iiSN][2]
         iipnt = pnts[iiWE,iiSN]
+        X[iilon,iilat], Y[iilon,iilat] = derotatepoint(iipnt,geo,rotation=rotation)
         if in(iipnt,geo)
             mask[iilon,iilat] = 1
             wgts[iilon,iilat] = cosd.(lat[iilon,iilat])
-            X[iilon,iilat], Y[iilon,iilat] = derotatepoint(iipnt,geo,rotation=rotation)
         else
             mask[iilon,iilat] = NaN
             wgts[iilon,iilat] = NaN
-            X[iilon,iilat] = NaN
-            Y[iilon,iilat] = NaN
         end
     end
 

--- a/src/grid/generalized.jl
+++ b/src/grid/generalized.jl
@@ -1,23 +1,29 @@
 """
     RegionGrid(
         geo  :: GeoRegion,
-        pnts :: Array{Point2{FT}}
+        pnts :: Array{Point2{FT}};
+        rotation :: Real = geo.θ
     ) where FT <: Real -> ggrd :: GeneralizedGrid
 
 Creates a `GeneralTilt` type based on the following arguments. This method is more suitable for structured non-rectilinear (e.g., curvilinear) grids of longitude and latitude points, such as in the output of WRF.
 
 Arguments
 =========
-- `geo` : A GeoRegion of interest
-- `pnts` : An array of `Point2` types containing the longitude/latitude points
+- `geo` : A GeoRegion of interest.
+- `pnts` : An array of `Point2` types containing the longitude/latitude points.
+
+Keyword Arguments
+=================
+- `rotation` : Angle (in degrees) at which to "unrotate" the gridded data about the GeoRegion centroid and project into the X-Y cartesian coordinate system (in meters).
 
 Returns
 =======
-- `ggrd` : A `GeneralTilt`
+- `ggrd` : A `GeneralTilt`.
 """
 function RegionGrid(
     geo  :: GeoRegion,
-    pnts :: Array{Point2{FT}}
+    pnts :: Array{Point2{FT}};
+    rotation :: Real = 0
 ) where FT <: Real
 
     @info "$(modulelog()) - Creating a GeneralizedGrid for the $(geo.name) GeoRegion"
@@ -35,7 +41,7 @@ function RegionGrid(
         end
     end
 
-    Xc,Yc = centroid(geo.geometry.polygon)
+    Xc,Yc = geo.geometry.centroid
 
     iWE = iW:iE; nlon = length(iWE)
     iSN = iS:iN; nlat = length(iSN)
@@ -70,7 +76,7 @@ function RegionGrid(
         iiSN = iSN[iilat]
         if in(pnts[iiWE,iiSN],geo)
             ir = haversine((lon[iilon,iilat],lat[iilon,iilat]),(Xc,Yc))
-            iθ = atand(lat[iilon,iilat]-Yc,lon[iilon,iilat]-Xc) - geo.θ
+            iθ = atand(lat[iilon,iilat]-Yc,lon[iilon,iilat]-Xc) - (geo.θ - rotation)
             X[iilon,iilat] = ir * cosd(iθ)
             Y[iilon,iilat] = ir * sind(iθ)
         else
@@ -79,6 +85,6 @@ function RegionGrid(
         end
     end
 
-    return GeneralizedGrid{FT}(lon,lat,ilon,ilat,mask,wgts,X,Y,geo.θ)
+    return GeneralizedGrid{FT}(lon,lat,ilon,ilat,mask,wgts,X,Y,rotation)
 
 end

--- a/src/grid/generalized.jl
+++ b/src/grid/generalized.jl
@@ -1,77 +1,8 @@
 """
     RegionGrid(
-        geo  :: Union{RectRegion,PolyRegion},
+        geo  :: GeoRegion,
         pnts :: Array{Point2{FT}}
-    ) where FT <: Real -> ggrd :: GeneralMask
-
-Creates a `GeneralMask` type based on the following arguments. This method is more suitable for structured non-rectilinear (e.g., curvilinear) grids of longitude and latitude points, such as in the output of WRF.
-
-Arguments
-=========
-- `geo` : A GeoRegion of interest
-- `pnts` : An array of `Point2` types containing the longitude/latitude points
-
-Returns
-=======
-- `ggrd` : A `GeneralMask`
-"""
-function RegionGrid(
-    geo  :: Union{RectRegion,PolyRegion},
-    pnts :: Array{Point2{FT}}
-) where FT <: Real
-
-    @info "$(modulelog()) - Creating a GeneralizedGrid for the $(geo.name) GeoRegion"
-
-    _,_,E,W = geo.bound
-
-    @debug "$(modulelog()) - Determining indices of longitude and latitude boundaries in the given dataset ..."
-
-    nlon,nlat = size(pnts)
-    iW = nlon; iE = 1
-    iS = nlat; iN = 1
-
-    for iilat = 1 : nlat, iilon = 1 : nlon
-        if in(pnts[iilon,iilat],geo)
-            iS = min(iS,iilat); iN = max(iN,iilat)
-            iW = min(iW,iilon); iE = max(iE,iilon)
-        end
-    end
-
-    iWE = iW:iE; nlon = length(iWE)
-    iSN = iS:iN; nlat = length(iSN)
-
-    lon  = zeros(nlon,nlat)
-    lat  = zeros(nlon,nlat)
-    ilon = zeros(nlon,nlat)
-    ilat = zeros(nlon,nlat)
-    mask = zeros(nlon,nlat)
-    wgts = zeros(nlon,nlat)
-
-    for iilat = 1 : nlat, iilon = 1 : nlon
-        iiWE = iWE[iilon]; ilon[iilon,iilat] = iiWE
-        iiSN = iSN[iilat]; ilat[iilon,iilat] = iiSN
-        lon[iilon,iilat] = pnts[iiWE,iiSN][1]
-        if lon[iilon,iilat] > E; lon[iilon,iilat] -= 360 end
-        if lon[iilon,iilat] < W; lon[iilon,iilat] += 360 end
-        lat[iilon,iilat] = pnts[iiWE,iiSN][2]
-        if in(pnts[iiWE,iiSN],geo)
-            mask[iilon,iilat] = 1
-            wgts[iilon,iilat] = cosd.(lat[iilon,iilat])
-        else
-            mask[iilon,iilat] = NaN
-            wgts[iilon,iilat] = 0
-        end
-    end
-
-    return GeneralMask{FT}(lon,lat,ilon,ilat,mask,wgts)
-
-end
-
-"""
-    RegionGrid(
-        geo  :: TiltRegion,
-        pnts :: Array{Point2{FT}}
-    ) where FT <: Real -> ggrd :: GeneralTilt
+    ) where FT <: Real -> ggrd :: GeneralizedGrid
 
 Creates a `GeneralTilt` type based on the following arguments. This method is more suitable for structured non-rectilinear (e.g., curvilinear) grids of longitude and latitude points, such as in the output of WRF.
 
@@ -85,7 +16,7 @@ Returns
 - `ggrd` : A `GeneralTilt`
 """
 function RegionGrid(
-    geo  :: TiltRegion,
+    geo  :: GeoRegion,
     pnts :: Array{Point2{FT}}
 ) where FT <: Real
 
@@ -149,6 +80,6 @@ function RegionGrid(
         end
     end
 
-    return GeneralTilt{FT}(lon,lat,ilon,ilat,mask,wgts,rotX,rotY)
+    return GeneralizedGrid{FT}(lon,lat,ilon,ilat,mask,wgts,rotX,rotY)
 
 end

--- a/src/grid/generalized.jl
+++ b/src/grid/generalized.jl
@@ -41,8 +41,6 @@ function RegionGrid(
         end
     end
 
-    Xc,Yc = geo.geometry.centroid
-
     iWE = iW:iE; nlon = length(iWE)
     iSN = iS:iN; nlat = length(iSN)
 
@@ -62,24 +60,14 @@ function RegionGrid(
         if lon[iilon,iilat] > geo.E; lon[iilon,iilat] -= 360 end
         if lon[iilon,iilat] < geo.W; lon[iilon,iilat] += 360 end
         lat[iilon,iilat] = pnts[iiWE,iiSN][2]
-        if in(pnts[iiWE,iiSN],geo)
+        iipnt = pnts[iiWE,iiSN]
+        if in(iipnt,geo)
             mask[iilon,iilat] = 1
             wgts[iilon,iilat] = cosd.(lat[iilon,iilat])
+            X[iilon,iilat], Y[iilon,iilat] = derotatepoint(iipnt,geo,rotation=rotation)
         else
             mask[iilon,iilat] = NaN
-            wgts[iilon,iilat] = 0
-        end
-    end
-
-    for iilat = 1 : nlat, iilon = 1 : nlon
-        iiWE = iWE[iilon]
-        iiSN = iSN[iilat]
-        if in(pnts[iiWE,iiSN],geo)
-            ir = haversine((lon[iilon,iilat],lat[iilon,iilat]),(Xc,Yc))
-            iθ = atand(lat[iilon,iilat]-Yc,lon[iilon,iilat]-Xc) - (geo.θ - rotation)
-            X[iilon,iilat] = ir * cosd(iθ)
-            Y[iilon,iilat] = ir * sind(iθ)
-        else
+            wgts[iilon,iilat] = NaN
             X[iilon,iilat] = NaN
             Y[iilon,iilat] = NaN
         end

--- a/src/grid/generalized.jl
+++ b/src/grid/generalized.jl
@@ -57,8 +57,8 @@ function RegionGrid(
         iiWE = iWE[iilon]; ilon[iilon,iilat] = iiWE
         iiSN = iSN[iilat]; ilat[iilon,iilat] = iiSN
         lon[iilon,iilat] = pnts[iiWE,iiSN][1]
-        if lon[iilon,iilat] > geo.E; lon[iilon,iilat] -= 360 end
-        if lon[iilon,iilat] < geo.W; lon[iilon,iilat] += 360 end
+        lon[iilon,iilat] > geo.E ? lon[iilon,iilat] -= 360 : nothing
+        lon[iilon,iilat] < geo.W ? lon[iilon,iilat] += 360 : nothing
         lat[iilon,iilat] = pnts[iiWE,iiSN][2]
         iipnt = pnts[iiWE,iiSN]
         if in(iipnt,geo)

--- a/src/grid/rectilinear.jl
+++ b/src/grid/rectilinear.jl
@@ -22,54 +22,7 @@ RegionGrid(
 ) = RegionGrid(geo,collect(lon),collect(lat))
 
 function RegionGrid(
-    geo :: Union{RectRegion,PolyRegion},
-    lon :: Vector{FT},
-    lat :: Vector{FT}
-) where FT <: Real
-
-    @info "$(modulelog()) - Creating a RectilinearGrid for the $(geo.name) GeoRegion"
-
-    @debug "$(modulelog()) - Determining indices of longitude and latitude boundaries in the given dataset ..."
-
-    nlon,nlat,iWE,iNS = bound2lonlat(geo.bound,lon,lat)
-
-    mask = Array{FT,2}(undef,length(nlon),length(nlat))
-    wgts = Array{FT,2}(undef,length(nlon),length(nlat))
-    for ilat in eachindex(nlat), ilon in eachindex(nlon)
-        ipnt = Point2(nlon[ilon],nlat[ilat])
-        if in(ipnt,geo)
-              mask[ilon,ilat] = 1
-              wgts[ilon,ilat] = cosd.(nlat[ilat])
-        else; mask[ilon,ilat] = NaN
-              wgts[ilon,ilat] = 0
-        end
-    end
-
-    return RLinearMask{FT}(nlon,nlat,iWE,iNS,mask,wgts)
-
-end
-
-"""
-    RegionGrid(
-        geo :: TiltRegion,
-        lon :: Union{Vector{<:Real},AbstractRange{<:Real},
-        lat :: Union{Vector{<:Real},AbstractRange{<:Real}
-    ) -> ggrd :: RLinearMask
-
-Creates a `RectGrid` or `PolyGrid` type based on the following arguments. This method is suitable for rectilinear grids of longitude/latitude output such as from Isca, or from satellite and reanalysis gridded datasets.
-
-Arguments
-=========
-- `geo` : A GeoRegion of interest
-- `lon` : A vector or `AbstractRange` containing the longitude points
-- `lat` : A vector or `AbstractRange` containing the latitude points
-
-Returns
-=======
-- `ggrd` : A `RectilinearGrid`
-"""
-function RegionGrid(
-    geo :: TiltRegion,
+    geo :: GeoRegion,
     lon :: Vector{FT},
     lat :: Vector{FT}
 ) where FT <: Real
@@ -105,7 +58,7 @@ function RegionGrid(
         end
     end
 
-    return RLinearTilt{FT}(nlon,nlat,iWE,iNS,mask,wgts,rotX,rotY)
+    return RectilinearGrid{FT}(nlon,nlat,iWE,iNS,mask,wgts,rotX,rotY)
 
 end
 

--- a/src/grid/rectilinear.jl
+++ b/src/grid/rectilinear.jl
@@ -136,7 +136,7 @@ function bound2lonlat(
 
     @info "$(modulelog()) - Creating vector of longitude indices to extract ..."
     if     iW < iE; iWE = vcat(iW:iE)
-    elseif iW > iE || (iW == iE && modE != modW)
+    elseif iW > iE || (iW == iE && gridbounds[3] != gridbounds[4])
         iWE = vcat(iW:length(rlon),1:iE); nlon[1:(iW-1)] .+= 360
     else; iWE = [iW];
     end
@@ -144,8 +144,8 @@ function bound2lonlat(
     nlon = nlon[iWE]
     nlat = rlat[iNS]
 
-    while maximum(nlon) > E; nlon .-= 360 end
-    while minimum(nlon) < W; nlon .+= 360 end
+    while maximum(nlon) > gridbounds[3]; nlon .-= 360 end
+    while minimum(nlon) < gridbounds[4]; nlon .+= 360 end
 
     return nlon,nlat,iWE,iNS
 

--- a/src/grid/rectilinear.jl
+++ b/src/grid/rectilinear.jl
@@ -39,7 +39,6 @@ function RegionGrid(
     @debug "$(modulelog()) - Determining indices of longitude and latitude boundaries in the given dataset ..."
 
     nlon,nlat,iWE,iNS = bound2lonlat([geo.N,geo.S,geo.E,geo.W],lon,lat)
-    Xc,Yc = geo.geometry.centroid
 
     mask = Array{FT,2}(undef,length(nlon),length(nlat))
     wgts = Array{FT,2}(undef,length(nlon),length(nlat))

--- a/src/grid/rectilinear.jl
+++ b/src/grid/rectilinear.jl
@@ -49,15 +49,13 @@ function RegionGrid(
 
     for ilat in eachindex(nlat), ilon in eachindex(nlon)
         ipnt = Point2(nlon[ilon],nlat[ilat])
+        X[ilon,ilat], Y[ilon,ilat] = derotatepoint(ipnt,geo,rotation=rotation)
         if in(ipnt,geo)
             mask[ilon,ilat] = 1
             wgts[ilon,ilat] = cosd.(nlat[ilat])
-            X[ilon,ilat], Y[ilon,ilat] = derotatepoint(ipnt,geo,rotation=rotation)
         else
             mask[ilon,ilat] = NaN
             wgts[ilon,ilat] = NaN
-            X[ilon,ilat] = NaN
-            Y[ilon,ilat] = NaN
         end
     end
 

--- a/src/grid/rectilinear.jl
+++ b/src/grid/rectilinear.jl
@@ -52,16 +52,13 @@ function RegionGrid(
         ipnt = Point2(nlon[ilon],nlat[ilat])
         if in(ipnt,geo)
             mask[ilon,ilat] = 1
-            ir = haversine((nlon[ilon],nlat[ilat]),(Xc,Yc))
-            iθ = atand(nlat[ilat]-Yc, nlon[ilon]-Xc) - (geo.θ - rotation)
-            X[ilon,ilat] = ir * cosd(iθ)
-            Y[ilon,ilat] = ir * sind(iθ)
             wgts[ilon,ilat] = cosd.(nlat[ilat])
+            X[ilon,ilat], Y[ilon,ilat] = derotatepoint(ipnt,geo,rotation=rotation)
         else
             mask[ilon,ilat] = NaN
+            wgts[ilon,ilat] = NaN
             X[ilon,ilat] = NaN
             Y[ilon,ilat] = NaN
-            wgts[ilon,ilat] = 0
         end
     end
 

--- a/src/grid/rectilinear.jl
+++ b/src/grid/rectilinear.jl
@@ -47,13 +47,13 @@ function RegionGrid(
             mask[ilon,ilat] = 1
             ir = haversine((nlon[ilon],nlat[ilat]),(Xc,Yc))
             iθ = atand(nlat[ilat]-Yc, nlon[ilon]-Xc) - geo.θ
-            rotX[ilon,ilat] = ir * cosd(iθ)
-            rotY[ilon,ilat] = ir * sind(iθ)
+            X[ilon,ilat] = ir * cosd(iθ)
+            Y[ilon,ilat] = ir * sind(iθ)
             wgts[ilon,ilat] = cosd.(nlat[ilat])
         else
             mask[ilon,ilat] = NaN
-            rotX[ilon,ilat] = NaN
-            rotY[ilon,ilat] = NaN
+            X[ilon,ilat] = NaN
+            Y[ilon,ilat] = NaN
             wgts[ilon,ilat] = 0
         end
     end

--- a/src/grid/unstructured.jl
+++ b/src/grid/unstructured.jl
@@ -28,8 +28,6 @@ function RegionGrid(
 
     @info "$(modulelog()) - Creating a RegionMask for the $(geo.name) GeoRegion based on an array of longitude and latitude points"
 
-    Xc,Yc = geo.geometry.centroid
-
     npnt = length(pnts)
     lon  = zeros(npnt)
     lat  = zeros(npnt)
@@ -51,10 +49,7 @@ function RegionGrid(
         if lon[ii] < geo.W; lon[ii] += 360 end
         lat[ii] = pnts[ipnt[ii]][2]
         wgts[ii] = cosd(pnts[ipnt[ii]][2])
-        ir = haversine((lon[ii],lat[ii]),(Xc,Yc))
-        iθ = atand(lat[ii]-Yc,lon[ii]-Xc) - (geo.θ - rotation)
-        X[ii] = ir * cosd(iθ)
-        Y[ii] = ir * sind(iθ)
+        X[ii],Y[ii] = derotatepoint(lon[ii],lat[ii],geo,rotation=rotation)
     end
 
     return VectorTilt{FT}(lon,lat,ipnt,wgts,X,Y,rotation)

--- a/src/grid/unstructured.jl
+++ b/src/grid/unstructured.jl
@@ -44,12 +44,13 @@ function RegionGrid(
     npnt = length(ipnt)
 
     for ii = 1 : npnt
-        lon[ii] = pnts[ipnt[ii]][1]
-        if lon[ii] > geo.E; lon[ii] -= 360 end
-        if lon[ii] < geo.W; lon[ii] += 360 end
-        lat[ii] = pnts[ipnt[ii]][2]
-        wgts[ii] = cosd(pnts[ipnt[ii]][2])
-        X[ii],Y[ii] = derotatepoint(lon[ii],lat[ii],geo,rotation=rotation)
+        iipnt = pnts[ipnt[ii]]
+        lon[ii] = iipnt[1]
+        lon[ii] > geo.E ? lon[ii] -= 360 : nothing
+        lon[ii] < geo.W ? lon[ii] += 360 : nothing
+        lat[ii] = iipnt[2]
+        wgts[ii] = cosd(iipnt[2])
+        X[ii],Y[ii] = derotatepoint(iipnt,geo,rotation=rotation)
     end
 
     return VectorTilt{FT}(lon,lat,ipnt,wgts,X,Y,rotation)

--- a/src/grid/unstructured.jl
+++ b/src/grid/unstructured.jl
@@ -1,6 +1,6 @@
 """
     RegionGrid(
-        geo  :: Union{RectRegion,PolyRegion},
+        geo  :: GeoRegion,
         pnts :: Vector{Point2{FT}}
     ) where FT <: Real -> ggrd :: VectorMask
 
@@ -16,58 +16,7 @@ Returns
 - `ggrd` : A `VectorMask`
 """
 function RegionGrid(
-    geo  :: Union{RectRegion,PolyRegion},
-    pnts :: Vector{Point2{FT}}
-) where FT <: Real
-
-    @info "$(modulelog()) - Creating a RegionMask for the $(geo.name) GeoRegion based on an array of longitude and latitude points"
-
-    _,_,E,W = geo.bound
-
-    npnt = length(pnts)
-    lon  = zeros(npnt)
-    lat  = zeros(npnt)
-    ipnt = zeros(npnt)
-    wgts = zeros(npnt)
-
-    for ii in 1 : npnt
-        if in(pnts[ii],geo); ipnt[ii] = ii; else; ipnt[ii] = NaN end
-    end
-
-    ipnt = ipnt[.!isnan.(ipnt)]; ipnt = Int.(ipnt)
-    npnt = length(ipnt)
-
-    for ii = 1 : npnt
-        lon[ii] = pnts[ipnt[ii]][1]
-        if lon[ii] > E; lon[ii] -= 360 end
-        if lon[ii] < W; lon[ii] += 360 end
-        lat[ii] = pnts[ipnt[ii]][2]
-        wgts[ii] = cosd(pnts[ipnt[ii]][2])
-    end
-
-    return VectorMask{FT}(lon,lat,ipnt,wgts)
-
-end
-
-"""
-    RegionGrid(
-        geo  :: TiltRegion,
-        pnts :: Vector{Point2{FT}}
-    ) where FT <: Real -> ggrd :: VectorTilt
-
-Creates a `VectorTilt` type based on a vector of 
-
-Arguments
-=========
-- `geo` : A GeoRegion of interest
-- `pnts` : A `Vector` of `Float` Types, containing the longitude points
-
-Returns
-=======
-- `ggrd` : A `VectorTilt`
-"""
-function RegionGrid(
-    geo  :: TiltRegion,
+    geo  :: GeoRegion,
     pnts :: Vector{Point2{FT}}
 ) where FT <: Real
 

--- a/src/grid/unstructured.jl
+++ b/src/grid/unstructured.jl
@@ -22,16 +22,15 @@ function RegionGrid(
 
     @info "$(modulelog()) - Creating a RegionMask for the $(geo.name) GeoRegion based on an array of longitude and latitude points"
 
-    _,_,E,W = geo.bound
-    X,Y,_,_,θ = geo.tilt
+    Xc,Yc = centroid(geo.geometry.polygon)
 
     npnt = length(pnts)
     lon  = zeros(npnt)
     lat  = zeros(npnt)
     ipnt = zeros(npnt)
     wgts = zeros(npnt)
-    rotX = zeros(npnt)
-    rotY = zeros(npnt)
+    X = zeros(npnt)
+    Y = zeros(npnt)
 
     for ii in 1 : npnt
         if in(pnts[ii],geo); ipnt[ii] = ii; else; ipnt[ii] = NaN end
@@ -42,16 +41,16 @@ function RegionGrid(
 
     for ii = 1 : npnt
         lon[ii] = pnts[ipnt[ii]][1]
-        if lon[ii] > E; lon[ii] -= 360 end
-        if lon[ii] < W; lon[ii] += 360 end
+        if lon[ii] > geo.E; lon[ii] -= 360 end
+        if lon[ii] < geo.W; lon[ii] += 360 end
         lat[ii] = pnts[ipnt[ii]][2]
         wgts[ii] = cosd(pnts[ipnt[ii]][2])
-        ir = sqrt((lon[ii]-X)^2 + (lat[ii]-Y)^2)
-        iθ = atand(lat[ii]-Y, lon[ii]-X) - θ
-        rotX[ii] = ir * cosd(iθ)
-        rotY[ii] = ir * sind(iθ)
+        ir = haversine((lon[ii],lat[ii]),(Xc,Yc))
+        iθ = atand(lat[ii]-Yc,lon[ii]-Xc) - geo.θ
+        X[ii] = ir * cosd(iθ)
+        Y[ii] = ir * sind(iθ)
     end
 
-    return VectorTilt{FT}(lon,lat,ipnt,wgts,rotX,rotY)
+    return VectorTilt{FT}(lon,lat,ipnt,wgts,X,Y,geo.θ)
 
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,4 +1,4 @@
-function show(io::IO, ggrd::RLinearMask)
+function show(io::IO, ggrd::RectilinearGrid)
 	nlon = length(ggrd.ilon)
 	nlat = length(ggrd.ilat)
     print(
@@ -8,6 +8,9 @@ function show(io::IO, ggrd::RLinearMask)
 		"    Latitude Indices      (ilat) : ", ggrd.ilat, '\n',
 		"    Longitude Points       (lon) : ", ggrd.lon,  '\n',
 		"    Latitude Points        (lat) : ", ggrd.lat,  '\n',
+		"    Rotated X Coordinates    (X)",
+		"    Rotated Y Coordinates    (Y)",
+		"    Rotation (°)             (θ) : ", ggrd.θ,  '\n',
 		"    RegionGrid Mask       (mask)", '\n',
 		"    RegionGrid Weights (weights)", '\n',
 		"    RegionGrid Size              : $(nlon) lon points x $(nlat) lat points\n",
@@ -15,82 +18,38 @@ function show(io::IO, ggrd::RLinearMask)
 	)
 end
 
-function show(io::IO, ggrd::RLinearTilt)
-	nlon = length(ggrd.ilon)
-	nlat = length(ggrd.ilat)
-	mask = ggrd.mask
-    print(
-		io,
-		"The RLinearTilt Grid type has the following properties:\n",
-		"    Longitude Indices     (ilon) : ", ggrd.ilon, '\n',
-		"    Latitude Indices      (ilat) : ", ggrd.ilat, '\n',
-		"    Longitude Points       (lon) : ", ggrd.lon,  '\n',
-		"    Latitude Points        (lat) : ", ggrd.lat,  '\n',
-		"    RegionGrid Mask       (mask)", '\n',
-		"    RegionGrid Weights (weights)", '\n',
-		"    Rotated X Points      (rotX)", '\n',
-		"    Rotated Y Points      (rotY)", '\n',
-		"    RegionGrid Size              : $(nlon) lon points x $(nlat) lat points\n",
-		"    RegionGrid Validity		  : $(sum(isone.(ggrd.mask))) / $(nlon*nlat)\n"
-	)
-end
-
-function show(io::IO, ggrd::GeneralMask)
+function show(io::IO, ggrd::GeneralizedGrid)
 	nlon = size(ggrd.lon,1)
 	nlat = size(ggrd.lon,2)
     print(
 		io,
 		"The GeneralMask type has the following properties:\n",
-		"    Longitude Points   (lon)", '\n',
-		"    Latitude Points    (lat)", '\n',
-		"    RegionGrid Mask    (mask)", '\n',
+		"    Longitude Indices     (ilon)", '\n',
+		"    Latitude Indices      (ilat)", '\n',
+		"    Longitude Points       (lon)", '\n',
+		"    Latitude Points        (lat)", '\n',
+		"    Rotated X Coordinates    (X)",
+		"    Rotated Y Coordinates    (Y)",
+		"    Rotation (°)             (θ) : ", ggrd.θ,  '\n',
+		"    RegionGrid Mask       (mask)", '\n',
 		"    RegionGrid Weights (weights)", '\n',
-		"    RegionGrid Size 	 : $(nlon) lon points x $(nlat) lat points\n",
-		"    RegionGrid Validity : $(sum(isone.(ggrd.mask))) / $(nlon*nlat)\n"
+		"    RegionGrid Size 	          : $(nlon) lon points x $(nlat) lat points\n",
+		"    RegionGrid Validity          : $(sum(isone.(ggrd.mask))) / $(nlon*nlat)\n"
 	)
 end
 
-function show(io::IO, ggrd::GeneralTilt)
-	nlon = size(ggrd.lon,1)
-	nlat = size(ggrd.lon,2)
-    print(
-		io,
-		"The GeneralTilt type has the following properties:\n",
-		"    Longitude Points   (lon)", '\n',
-		"    Latitude Points    (lat)", '\n',
-		"    RegionGrid Mask    (mask)", '\n',
-		"    RegionGrid Weights (weights)", '\n',
-		"    Rotated X Points   (rotX)", '\n',
-		"    Rotated Y Points   (rotY)", '\n',
-		"    RegionGrid Size 	 : $(nlon) lon points x $(nlat) lat points\n",
-		"    RegionGrid Validity : $(sum(isone.(ggrd.mask))) / $(nlon*nlat)\n"
-	)
-end
-
-function show(io::IO, ggrd::VectorMask)
+function show(io::IO, ggrd::UnstructuredGrid)
 	nlon = size(ggrd.lon)
     print(
 		io,
 		"The VectorMask Grid type has the following properties:\n",
+		"    Indices             (ipoint) : ", ggrd.ipoint, '\n',
 		"    Longitude Points       (lon) : ", ggrd.lon,  '\n',
 		"    Latitude Points        (lat) : ", ggrd.lat,  '\n',
-		"    Longitude Indices   (ipoint) : ", ggrd.ipoint, '\n',
+		"    Rotated X Coordinates    (X)",
+		"    Rotated Y Coordinates    (Y)",
+		"    Rotation (°)             (θ) : ", ggrd.θ,  '\n',
 		"    RegionGrid Weights (weights)", '\n',
-		"    RegionGrid Size 	 : $(nlon) lon points x $(nlat) lat points\n",
-	)
-end
-
-function show(io::IO, ggrd::VectorTilt)
-	nlon = size(ggrd.lon)
-    print(
-		io,
-		"The VectorTilt Grid type has the following properties:\n",
-		"    Longitude Points       (lon) : ", ggrd.lon,  '\n',
-		"    Latitude Points        (lat) : ", ggrd.lat,  '\n',
-		"    Longitude Indices   (ipoint) : ", ggrd.ipoint, '\n',
-		"    RegionGrid Weights (weights)", '\n',
-		"    Rotated X Points      (rotX)", '\n',
-		"    Rotated Y Points      (rotY)", '\n',
-		"    RegionGrid Size 	 : $(nlon) lon points x $(nlat) lat points\n",
+		"    RegionGrid Size 			  : $(nlon) points\n",
 	)
 end


### PR DESCRIPTION
In `v0.1` of RegionGrids.jl, we make the API consistent with GeoRegions.jl `v8`

# Milestones for RegionGrid Types
- [x] Integrate with v8 of GeoRegions.jl
  - [x] Update `[compat]` bounds
  - [x] Merge v8 branch of GeoRegions.jl (see https://github.com/GeoRegionsEcosystem/GeoRegions.jl/pull/14) and register it
- [x] No more differentiation between "non-rotated" and "rotated/tilted" GeoRegions
  - [x] No more `XMask` and `XTilt` types, merge into`XGrid` types that contain the `rotation`, `X` and `Y` fields for projection based on rotation
  - [x] Ensure that "derotation" works as advertised, similar to how it is in GeoRegions.jl
  - [x] Need to update the RegionGrid creation functions
  - [x] Check and see if `extract` functionality needs to change

# Optional Milestones
- [ ] Stuff goes here when I think of it